### PR TITLE
Split an index over multiple ones

### DIFF
--- a/db/document_datastore.rb
+++ b/db/document_datastore.rb
@@ -1,6 +1,6 @@
 require 'google/cloud/datastore'
 require_relative 'document_entity'
-require_relative 'log/log'
+require_relative '../log/log'
 
 # DocumentDatastore connects to the Datastore in Google Cloud Platform.
 class DocumentDatastore

--- a/db/document_datastore.rb
+++ b/db/document_datastore.rb
@@ -7,7 +7,7 @@ class DocumentDatastore
   MAX_URL_LIST = 3000
 
   DOCUMENT_KIND = {'DEV' => 'page_dev', 'PROD' => 'page'}
-  INDEX_KIND = {'DEV' => 'in_dev', 'PROD' => 'index'}
+  INDEX_KIND = {'DEV' => 'index_dev', 'PROD' => 'index'}
 
   def initialize(env)
     @@datastore ||= Google::Cloud::Datastore.new(project_id: 'codegust')

--- a/db/document_datastore.rb
+++ b/db/document_datastore.rb
@@ -1,5 +1,6 @@
 require 'google/cloud/datastore'
 require_relative 'document_entity'
+require_relative 'log/log'
 
 # DocumentDatastore connects to the Datastore in Google Cloud Platform.
 class DocumentDatastore
@@ -18,9 +19,11 @@ class DocumentDatastore
     @index_kind = INDEX_KIND[@env]
     @largest_timestamp = Time.now.to_i
     @offset_cache = {}  # TODO not threadsafe :(
+    Log::LOGGER.info('datastore') { "Initialized with largest_timestamp = #{@largest_timestamp}" }
   end
 
   def query(limit)
+    Log::LOGGER.info('datastore') { "Query with largest_timestamp = #{@largest_timestamp}" }
     documents = []
     query = @@datastore.query(@document_kind)
                          .where('timestamp', '<', @largest_timestamp)
@@ -37,8 +40,9 @@ class DocumentDatastore
 
   def add_indexes(index_hash)
     index_hash.each_key do |index|
-      current_hash, offset = get_current_hash(index)
+      Log::LOGGER.info('datastore') { "Adding index = #{index}" }
 
+      current_hash, offset = get_current_hash(index)
       new_index_value, remaining_index_value = compute_index_value(current_hash, index_hash[index])
 
       save(index + offset.to_s, new_index_value)


### PR DESCRIPTION
We split one index over multiple ones as Datastore has a limit of 1Mb per field. Indexes are named as follows: "index0", "index1", ... "indexN".
Currently this solution is not thread safe.